### PR TITLE
Fix typo xmlsjon -> xmljson

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ xmljson
         :target: https://pypi.python.org/pypi/xmljson
 
 
-xmlsjon converts XML into Python dictionary structures (trees, like in JSON) and vice-versa.
+xmljson converts XML into Python dictionary structures (trees, like in JSON) and vice-versa.
 
 About
 -----

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('HISTORY.rst') as history_file:
 setup(
     name='xmljson',
     version=xmljson.__version__,
-    description="xmlsjon converts XML into Python dictionary structures "
+    description="xmljson converts XML into Python dictionary structures "
                 "(trees, like in JSON) and vice-versa.",
     long_description=readme + '\n\n' + history,
     author="S Anand",


### PR DESCRIPTION
This should also fix https://pypi.python.org/pypi/xmljson description.
