### PR TITLE
Add namespace support

### DIFF
--- a/tests/test_xmljson.py
+++ b/tests/test_xmljson.py
@@ -18,7 +18,6 @@ from lxml.doctestcompare import LXMLOutputChecker
 import lxml.html
 import lxml.etree
 import xml.etree.cElementTree
-import xml.etree
 import xmljson
 
 

--- a/tests/test_xmljson.py
+++ b/tests/test_xmljson.py
@@ -18,6 +18,7 @@ from lxml.doctestcompare import LXMLOutputChecker
 import lxml.html
 import lxml.etree
 import xml.etree.cElementTree
+import xml.etree
 import xmljson
 
 
@@ -63,6 +64,15 @@ class TestXmlJson(unittest.TestCase):
             root = conv.etree(result)
             t1 = fromstring(xmlstring)
             t2 = root[0]
+            try:
+                t1.nsmap
+            except:
+                ns = {'charlie': "http://some-other-namespace"}
+
+                r1 = t1.find('charlie:joe', ns)
+                r2 = t2.find('charlie:joe', ns)
+                self.assertEqual(r1.tag, r2.tag)
+                return
             self.assertEqual(t1.nsmap, t2.nsmap)
         return compare
 
@@ -174,7 +184,7 @@ class TestBadgerFish(TestXmlJson):
     def test_xml_namespace(self):
         'Checks nsmap attribute of root tag'
         eq = self.check_nsmap(xmljson.badgerfish)
-        eq('<alice xmlns="http://some-namespace" xmlns:charlie="http://some-other-namespace">bob</alice>')
+        eq('<alice xmlns="http://some-namespace" xmlns:charlie="http://some-other-namespace"><charlie:joe>bob</charlie:joe></alice>')
 
     def test_custom_dict(self):
         'Conversion to dict uses OrderedDict'

--- a/xmljson/__init__.py
+++ b/xmljson/__init__.py
@@ -2,10 +2,12 @@
 
 import sys
 from collections import Counter, OrderedDict
+from io import BytesIO
+
 try:
-    from lxml.etree import Element
+    from lxml.etree import Element, iterparse, ElementTree, tostring
 except ImportError:
-    from xml.etree.cElementTree import Element
+    from xml.etree.cElementTree import Element, iterparse, ElementTree
 
 __author__ = 'S Anand'
 __email__ = 'root.node@gmail.com'
@@ -19,7 +21,7 @@ if sys.version_info[0] == 3:
 
 class XMLData(object):
     def __init__(self, xml_fromstring=True, xml_tostring=True, element=None, dict_type=None,
-                 list_type=None, attr_prefix=None, text_content=None, simple_text=False):
+                 list_type=None, attr_prefix=None, text_content=None, ns_name=None, simple_text=False):
         # xml_fromstring == False(y) => '1' -> '1'
         # xml_fromstring == True     => '1' -> 1
         # xml_fromstring == fn       => '1' -> fn(1)
@@ -44,6 +46,13 @@ class XMLData(object):
         # simple_text == True               => '<x>a</x>' = {'x': 'a'}
         self.simple_text = simple_text
 
+        self.ns_name = ns_name
+        try:
+            elem = Element("html", nsmap={None: 'test'})
+            self.lxml_lib = True
+        except:
+            self.lxml_lib = False
+
     @staticmethod
     def _tostring(value):
         'Convert value to XML compatible string'
@@ -51,6 +60,8 @@ class XMLData(object):
             value = 'true'
         elif value is False:
             value = 'false'
+        else:
+            value = str(value)
         return unicode(value)       # noqa: convert to whatever native unicode repr
 
     @staticmethod
@@ -64,7 +75,10 @@ class XMLData(object):
         elif std_value == 'false':
             return False
         try:
-            return int(std_value)
+            if std_value.startswith('0'):
+                return std_value
+            else:
+                return int(std_value)
         except ValueError:
             pass
         try:
@@ -76,6 +90,7 @@ class XMLData(object):
     def etree(self, data, root=None):
         'Convert data structure into a list of etree.Element'
         result = self.list() if root is None else root
+
         if isinstance(data, (self.dict, dict)):
             for key, value in data.items():
                 value_is_list = isinstance(value, (self.list, list))
@@ -88,7 +103,18 @@ class XMLData(object):
                             key = key.lstrip(self.attr_prefix)
                             # @xmlns: {$: xxx, svg: yyy} becomes xmlns="xxx" xmlns:svg="yyy"
                             if value_is_dict:
-                                raise ValueError('XML namespaces not yet supported')
+                                if self.lxml_lib:
+                                    if key == self.ns_name.lstrip(self.attr_prefix):
+                                        # Actually nothing to do here
+                                        pass
+                                else:
+                                    for k in value.keys():
+                                        if k == self.text_content:
+                                            k_default = 'ns0'
+                                            self.ns_counter += 1
+                                            result.set('xmlns:' + k_default, self._tostring(value[k]))
+                                        else:
+                                            result.set('xmlns:' + k, self._tostring(value[k]))
                             else:
                                 result.set(key, self._tostring(value))
                             continue
@@ -105,8 +131,34 @@ class XMLData(object):
                 # Add other keys as one or more children
                 values = value if value_is_list else [value]
                 for value in values:
-                    elem = self.element(key)
-                    result.append(elem)
+                    if value_is_dict:
+                        # Add namespaces to nodes if @xmlns present
+                        if self.ns_name in value.keys() and self.lxml_lib:
+                            NS_MAP = self.dict()
+                            for k in value[self.ns_name]:
+                                prefix = k
+                                if prefix == self.text_content:
+                                    prefix = 'ns0'
+                                uri = value[self.ns_name][k]
+
+                                if ':' in key:
+                                    prefix, tag = key.split(':')
+                                    key = tag
+
+                                NS_MAP[prefix] = uri
+                                continue
+
+                            if len(value[self.ns_name]) > 1:
+                                uri = ''
+                            elem = self.element('{0}{1}'.format('{' + uri + '}', key), nsmap=NS_MAP)
+                            result.append(elem)
+                        else:
+                            elem = self.element(key)
+                            result.append(elem)
+                    else:
+                        elem = self.element(key)
+                        result.append(elem)
+
                     # Treat scalars as text content, not children (Parker)
                     if not isinstance(value, (self.dict, dict, self.list, list)):
                         if self.text_content:
@@ -122,10 +174,36 @@ class XMLData(object):
     def data(self, root):
         'Convert etree.Element into a dictionary'
         value = self.dict()
+        root = XMLData._process_ns(self, element=root)
+
         children = [node for node in root if isinstance(node.tag, basestring)]
-        for attr, attrval in root.attrib.items():
-            attr = attr if self.attr_prefix is None else self.attr_prefix + attr
-            value[attr] = self._fromstring(attrval)
+
+        # form lxml.Element with namespaces if present
+        if self.lxml_lib:
+            if root.tag.startswith('{'):
+                root.tag = root.tag.split('}')[1]
+                nsmap = root.nsmap
+                value[self.ns_name] = {}
+
+                for key in nsmap.keys():
+                    value[self.ns_name].update({key: nsmap[key]})
+            else:
+                for attr, attrval in root.attrib.items():
+                    attr = attr if self.attr_prefix is None else self.attr_prefix + attr
+                    value[attr] = self._fromstring(attrval)
+        else:
+            for attr, attrval in root.attrib.items():
+                attr = attr if self.attr_prefix is None else self.attr_prefix + attr
+
+                if self.attr_prefix:
+                    if self.ns_name in attr:
+                        prefix = attr.split(':')[1]
+                        value[attr.replace(prefix, '')] = {prefix: self._fromstring(attrval)}
+                    else:
+                        value[attr] = self._fromstring(attrval)
+                else:
+                    value[attr] = self._fromstring(attrval)
+
         if root.text and self.text_content is not None:
             text = root.text.strip()
             if text:
@@ -133,8 +211,10 @@ class XMLData(object):
                     value = self._fromstring(text)
                 else:
                     value[self.text_content] = self._fromstring(text)
+
         count = Counter(child.tag for child in children)
         for child in children:
+            child = XMLData._process_ns(self, child)
             if count[child.tag] == 1:
                 value.update(self.data(child))
             else:
@@ -142,11 +222,61 @@ class XMLData(object):
                 result += self.data(child).values()
         return self.dict([(root.tag, value)])
 
+    @staticmethod
+    def _process_ns(cls, element):
+        if element.tag.startswith('}'):
+            if any([True if k.split(':')[0] == 'xmlns' else False for k in element.attrib.keys()]):
+                revers_attr = {v:k for k,v in element.attrib.items()}
+
+                end_prefix = element.tag.find('}')
+                uri = element.tag[:end_prefix+1]
+                key_prefix = revers_attr[uri.strip('{}')]
+                prefix = key_prefix.split(':')[1]
+
+                element.tag = element.tag.replace(uri, prefix + ':')
+
+                # trick to determine if given element is root element
+                try:
+                    _ = element.getroot()
+                    element.attrib.pop(key_prefix, None)
+                except:
+                    pass
+        else:
+            ns_keys = [k if k.split(':')[0] == 'xmlns' else None for k in element.attrib.keys()]
+            for key in ns_keys:
+                if key:
+                    element.attrib.pop(key, None)
+        return element
+
+    @classmethod
+    def parse_nsmap(cls, file):
+        # Parse given file-like xml object for namespaces
+        if isinstance(file, (str)):
+            file = BytesIO(file.encode('utf-8'))
+
+        events = "start", "start-ns", "end-ns"
+        root = None
+        ns_map = []
+
+        for event, elem in iterparse(file, events):
+            if event == "start-ns":
+                ns_map.append(elem)
+            elif event == "end-ns":
+                ns_map.pop()
+            elif event == "start":
+                if root is None:
+                    root = elem
+                if ns_map:
+                    ns_prefix = ns_map[0][0]
+                    ns_uri = ns_map[0][1]
+                    elem.set('xmlns:{}'.format(ns_prefix), ns_uri)
+        return ElementTree(root).getroot()
+
 
 class BadgerFish(XMLData):
     'Converts between XML and data using the BadgerFish convention'
     def __init__(self, **kwargs):
-        super(BadgerFish, self).__init__(attr_prefix='@', text_content='$', **kwargs)
+        super(BadgerFish, self).__init__(attr_prefix='@', text_content='$', ns_name='@xmlns', **kwargs)
 
 
 class GData(XMLData):

--- a/xmljson/__init__.py
+++ b/xmljson/__init__.py
@@ -9,8 +9,6 @@ try:
 except ImportError:
     from xml.etree.cElementTree import Element, iterparse, ElementTree
 
-# from lxml.etree import Element, iterparse, ElementTree, tostring
-
 __author__ = 'S Anand'
 __email__ = 'root.node@gmail.com'
 __version__ = '0.1.7'


### PR DESCRIPTION
Hi.

I tried to add namespace support for BadgerFish converter.
The main problem i have faced - support for standard xml library and lxml. Their namespace implementation slightly differs so there is no simple methods to support them both in one way.

Because of a lack of experience my code is messy, sorry.

My implementation stands for one idea - give on the output exact thing that were received on the input.

Now examples of use:
- simple one; default namespace without prefix. 

``` python
element = fromstring('<root xmlns="http://dot.com"><joe>string</joe></root>')
dict_obj = xmljson.badgerfish.data(element)

print(dict_obj)
>>> OrderedDict([('root', OrderedDict([('@xmlns', {None: 'http://dot.com'}), ('joe', OrderedDict([('@xmlns', {None: 'http://dot.com'}), ('$', 'string')]))]))])

element = xmljson.badgerfish.etree(dict_obj)
print(tostring(element[0]))
>>> b'<root xmlns="http://dot.com"><joe>string</joe></root>'

print(element[0].nsmap) # lxml only!
>>> {None: 'http://dot.com'}
```
- both root and child node have namespace prefix; root node have multiple namespaces

``` python
element = fromstring('<abc:root xmlns:abc="http://dot.com" xmlns:xyz="http://com.doc"><xyz:joe>string</xyz:joe></abc:root>')
dict_obj = xmljson.badgerfish.data(element)

print(dict_obj)
>>> OrderedDict([('root', OrderedDict([('@xmlns', {'xyz': 'http://com.doc', 'abc': 'http://dot.com'}), ('joe', OrderedDict([('@xmlns', {'xyz': 'http://com.doc'}), ('$', 'string')]))]))])

element = xmljson.badgerfish.etree(dict_obj)
print(tostring(element[0]))
>>> b'<root xmlns:xyz="http://com.doc" xmlns:abc="http://dot.com"><xyz:joe>string</xyz:joe></root>'

print(element[0].nsmap) # lxml only!
>>> {'xyz': 'http://com.doc', 'abc': 'http://dot.com'}
```

If you have some questions - ask, will be glad to answer.
