### PR TITLE
fix missing root element in parker conversion

### DIFF
--- a/xmljson/__init__.py
+++ b/xmljson/__init__.py
@@ -183,7 +183,7 @@ class Parker(XMLData):
             else:
                 result.setdefault(child.tag, self.list()).append(self.data(child))
 
-        return result
+        return self.dict([(root.tag, result)])
 
 badgerfish = BadgerFish()
 gdata = GData()


### PR DESCRIPTION
For the parker conversion the root element is ignored. Is this intentional?