### PR TITLE
Fix to avoid invalid JSON output

### DIFF
--- a/xmljson/__init__.py
+++ b/xmljson/__init__.py
@@ -56,21 +56,29 @@ class XMLData(object):
     @staticmethod
     def _fromstring(value):
         '''Convert XML string value to None, boolean, int or float'''
-        if not value:
+        # NOTE: Is this even possible ?
+        if value is None:
             return None
-        std_value = value.strip().lower()
-        if std_value == 'true':
+
+        # FIXME: In XML, booleans are either 0/false or 1/true (lower-case !)
+        if value.lower() == 'true':
             return True
-        elif std_value == 'false':
+        elif value.lower() == 'false':
             return False
+
+        # FIXME: Using int() or float() is eating whitespaces unintendedly here
         try:
-            return int(std_value)
+            return int(value)
         except ValueError:
             pass
+
         try:
-            return float(std_value)
+            # Test for infinity and NaN values
+            if float('-inf') < float(value) < float('inf'):
+                return float(value)
         except ValueError:
             pass
+
         return value
 
     def etree(self, data, root=None):


### PR DESCRIPTION
This PR fixes a few issues:
- Do not return None on empty strings
- Do not return NaN or infinity in JSON (invalid)
- Do not strip the value (assume that if it is like this in XML, that's actually on purpose)

This fixes #23 

PS Do we have a location for adding unit-tests so we can test whether XMLData works as designed ?