### PR TITLE
Add ability to call module as CLI utility (`python -m`)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,37 @@ This is a pure-Python package built for Python 2.6+ and Python 3.0+. To set up::
 
     pip install xmljson
 
+
+Simple CLI utility
+------------------
+
+After installation, you can benefit from using this package as simple CLI utility. By now only XML to JSON conversion supported. Example::
+
+    $ python -m xmljson -h
+    usage: xmljson [-h] [-o OUT_FILE] [-c CONVERTER] [in_file]
+
+    positional arguments:
+      in_file
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -o OUT_FILE, --out-file OUT_FILE
+      -c CONVERTER, --converter CONVERTER
+
+    $ python -m xmljson -c parker mydata.xml
+    {
+      "foo": "spam",
+      "bar": 42
+    }
+
+This is a typical UNIX filter program: it reads file (or ``stdin``), processes it in some way (convert XML to JSON in this case), then prints it to ``stdout`` (or file). Example with pipe::
+
+    $ some-xml-producer | python -m xmljson | some-json-processor
+
+There is also ``pip``'s ``console_script`` entry-point, you can call this utility as ``x2j``::
+
+    $ x2j -c abdera mydata.xml
+
 Roadmap
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -46,4 +46,9 @@ setup(
     ],
     test_suite='tests',
     tests_require=['lxml'],
+    entry_points={
+        'console_scripts': [
+            'x2j = xmljson.__main__:main'
+        ]
+    }
 )

--- a/xmljson/__init__.py
+++ b/xmljson/__init__.py
@@ -17,6 +17,10 @@ if sys.version_info[0] == 3:
     basestring = str
 
 
+class Error(Exception): pass
+class UnknownDialectError(Error): pass
+
+
 class XMLData(object):
     def __init__(self, xml_fromstring=True, xml_tostring=True, element=None, dict_type=None,
                  list_type=None, attr_prefix=None, text_content=None, simple_text=False):
@@ -149,6 +153,23 @@ class XMLData(object):
                 result = value.setdefault(child.tag, self.list())
                 result += self.data(child).values()
         return self.dict([(root.tag, value)])
+
+    @staticmethod
+    def converter(dialect):
+        if dialect == 'badgerfish':
+            return BadgerFish()
+        elif dialect == 'gdata':
+            return GData()
+        elif dialect == 'yahoo':
+            return Yahoo()
+        elif dialect == 'parker':
+            return Parker()
+        elif dialect == 'abdera':
+            return Abdera()
+        elif dialect == 'cobra':
+            return Cobra()
+        else:
+            raise UnknownDialectError(dialect)
 
 
 class BadgerFish(XMLData):

--- a/xmljson/__main__.py
+++ b/xmljson/__main__.py
@@ -20,7 +20,7 @@ def main():
     args = parser.parse_args()
 
     with closing(args.in_file) as in_file, closing(args.out_file) as out_file:
-        json.dump(args.converter.data(etree.parse(in_file).getroot()), out_file, indent=2, ensure_ascii=False)
+        json.dump(args.converter.data(etree.parse(in_file).getroot()), out_file, indent=2)
 
 
 if __name__ == '__main__':

--- a/xmljson/__main__.py
+++ b/xmljson/__main__.py
@@ -1,0 +1,27 @@
+import argparse
+import json
+import sys
+from contextlib import closing
+
+from xmljson import XMLData
+
+try:
+    from lxml import etree
+except ImportError:
+    from xml.etree import ElementTree as etree
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='xmljson')
+    parser.add_argument('in_file', type=argparse.FileType(), nargs='?', default=sys.stdin)
+    parser.add_argument('-o', '--out-file', type=argparse.FileType('w'), default=sys.stdout)
+    parser.add_argument('-c', '--converter', type=XMLData.converter, default='parker')
+
+    args = parser.parse_args()
+
+    with closing(args.in_file) as in_file, closing(args.out_file) as out_file:
+        json.dump(args.converter.data(etree.parse(in_file).getroot()), out_file, indent=2, ensure_ascii=False)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
It is very usable package, but it is also very annoying to copy-paste same simple script again and again in every project I'm working on (that uses XML) to get the ability to quickly convert some unreadable messy XML to eye-pleasant well-formatted easily understandable JSON one.