### PR TITLE
Allow the dropping of tags that contain illegal characters in the XML spec

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 
 History
 -------
+0.1.9.1 (14 Nov 2018)
+~~~~~~~~~~~~~~~~~~~~~
+- Add the keyword argument "drop_invalid_tags=False" to the etree methods
+  to allow the suppression of the ValueError raised by lxml when a tag 
+  is encountered that contains illegal characters.
+
+Thanks to @Zurga
 
 0.1.9 (1 Aug 2017)
 ~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,13 @@ result is identical to::
 
 .. _etree.Element: http://effbot.org/zone/element-index.htm
 
+If the data contains keys which have characters which cannot be used in tag
+names by XML, these can be dropped by setting the ``drop_invalid_tags=True``
+in the etree method::
+
+    >>> bf.etree({'1': '2', 'test': 'works'}, drop_invalid_tags=True)
+    [<Element test at 0x7f4f91d1d088>]
+
 The result can be inserted into any existing root `etree.Element`_::
 
     >>> from xml.etree.ElementTree import Element, tostring
@@ -107,7 +114,6 @@ case). Override this behaviour using ``xml_fromstring``::
     >>> bf_str = BadgerFish(xml_tostring=str)       # convert using str()
     >>> tostring(bf_str.etree({'x': 1.23, 'y': True}, root=Element('root')))
     '<root><y>True</y><x>1.23</x></root>'
-
 
 Convert XML to data
 -------------------


### PR DESCRIPTION
If the data that is being parsed contains characters which are illegal in tag names (as specified here: https://www.w3schools.com/XML/xml_elements.asp), lxml will raise a ValueError. This is fine and expected if you control the data being sent to xmljson. In other cases you might want to be able to suppress the error and just silently drop the tags that are not allowed. I have added this by adding a "drop_invalid_tags" keyword argument to the "etree" methods.