### PR TITLE
Fix for 'single element array' issue.

### DIFF
--- a/xmljson/__init__.py
+++ b/xmljson/__init__.py
@@ -175,18 +175,21 @@ class XMLData(object):
 
 class BadgerFish(XMLData):
     '''Converts between XML and data using the BadgerFish convention'''
+
     def __init__(self, **kwargs):
         super(BadgerFish, self).__init__(attr_prefix='@', text_content='$', **kwargs)
 
 
 class GData(XMLData):
     '''Converts between XML and data using the GData convention'''
+
     def __init__(self, **kwargs):
         super(GData, self).__init__(text_content='$t', **kwargs)
 
 
 class Yahoo(XMLData):
     '''Converts between XML and data using the Yahoo convention'''
+
     def __init__(self, **kwargs):
         kwargs.setdefault('xml_fromstring', False)
         super(Yahoo, self).__init__(text_content='content', simple_text=True, **kwargs)
@@ -194,6 +197,7 @@ class Yahoo(XMLData):
 
 class Parker(XMLData):
     '''Converts between XML and data using the Parker convention'''
+
     def __init__(self, **kwargs):
         super(Parker, self).__init__(**kwargs)
 
@@ -225,6 +229,7 @@ class Parker(XMLData):
 
 class Abdera(XMLData):
     '''Converts between XML and data using the Abdera convention'''
+
     def __init__(self, **kwargs):
         super(Abdera, self).__init__(simple_text=True, text_content=True, **kwargs)
 
@@ -271,6 +276,7 @@ class Abdera(XMLData):
 # https://github.com/datacenter/cobra/blob/master/cobra/internal/codec/jsoncodec.py
 class Cobra(XMLData):
     '''Converts between XML and data using the Cobra convention'''
+
     def __init__(self, **kwargs):
         super(Cobra, self).__init__(simple_text=True, text_content=True,
                                     xml_fromstring=False, **kwargs)
@@ -357,6 +363,7 @@ class Cobra(XMLData):
 # Specified tags are considered as single element arrays if there is only one child
 class Spark(XMLData):
     '''Converts between XML and data using the Spark convention'''
+
     def __init__(self, **kwargs):
         super(Spark, self).__init__(**kwargs)
 
@@ -381,16 +388,16 @@ class Spark(XMLData):
         count = Counter(child.tag for child in children)
         result = self.dict()
         for child in children:
-            #For specified tags data is formatted as per 'single element array'
+            # For specified tags data is formatted as per 'single element array'
             if child.tag in single_element_array_tags:
-                result.setdefault(child.tag, self.list())
-                .append(self.data(child,single_element_array_tags=single_element_array_tags))
+                result.setdefault(child.tag, self.list()).append(self.data(
+                    child, single_element_array_tags=single_element_array_tags))
             elif count[child.tag] == 1:
-                result[child.tag] = self
-                .data(child,single_element_array_tags=single_element_array_tags)
+                result.setdefault(child.tag, self.list()).append(self.data(
+                    child, single_element_array_tags=single_element_array_tags))
             else:
-                result.setdefault(child.tag, self.list())
-                .append(self.data(child,single_element_array_tags=single_element_array_tags))
+                result.setdefault(child.tag, self.list()).append(self.data(
+                    child, single_element_array_tags=single_element_array_tags))
 
         return result
 

--- a/xmljson/__init__.py
+++ b/xmljson/__init__.py
@@ -352,7 +352,8 @@ class Cobra(XMLData):
 
         return self.dict([(unicode(root.tag), value)])
 
-# Converts XML to JSON using the Spark Convention.  
+
+# Converts XML to JSON using the Spark Convention.
 # Specified tags are considered as single element arrays if there is only one child
 class Spark(XMLData):
     '''Converts between XML and data using the Spark convention'''
@@ -370,9 +371,8 @@ class Spark(XMLData):
             root = new_root
         # If no children, just return the text
         children = [node for node in root if isinstance(node.tag, basestring)]
-
         if len(children) == 0:
-            #For specified tags data is formatted as per 'single element array'
+            # For specified tags data is formatted as per 'single element array'
             if root.tag in single_element_array_tags:
                 return [root.text]
             return self._fromstring(root.text)
@@ -381,15 +381,19 @@ class Spark(XMLData):
         count = Counter(child.tag for child in children)
         result = self.dict()
         for child in children:
-            #For specified tags data is formatted as per 'single element array' 
+            #For specified tags data is formatted as per 'single element array'
             if child.tag in single_element_array_tags:
-                result.setdefault(child.tag, self.list()).append(self.data(child,single_element_array_tags=single_element_array_tags)) 
+                result.setdefault(child.tag, self.list())
+                .append(self.data(child,single_element_array_tags=single_element_array_tags))
             elif count[child.tag] == 1:
-                result[child.tag] = self.data(child,single_element_array_tags=single_element_array_tags)
+                result[child.tag] = self
+                .data(child,single_element_array_tags=single_element_array_tags)
             else:
-                result.setdefault(child.tag, self.list()).append(self.data(child,single_element_array_tags=single_element_array_tags))
+                result.setdefault(child.tag, self.list())
+                .append(self.data(child,single_element_array_tags=single_element_array_tags))
 
         return result
+
 
 abdera = Abdera()
 badgerfish = BadgerFish()


### PR DESCRIPTION
Have added a method named Spark as it is like the Spark Convention.This is similar to the Parker method except that this method takes and extra list parameter 'single_element_array_tags'. Specified tags in this list are formatted in the json as single element arrays if there is only one child.
After importing the required modules we can call this method as:
formatted_json  = dumps(spark.data(fromstring('<xml>'), preserve_root=True, single_element_array_tags=['<tag 1>','<tag 2>']), sort_keys=True, indent=4)
