### PR TITLE
Don't strip whitespace in xml text values

### DIFF
--- a/xmljson/__init__.py
+++ b/xmljson/__init__.py
@@ -154,8 +154,8 @@ class XMLData(object):
             attr = attr if self.attr_prefix is None else self.attr_prefix + attr
             value[attr] = self._fromstring(attrval)
         if root.text and self.text_content is not None:
-            text = root.text.strip()
-            if text:
+            text = root.text
+            if text.strip():
                 if self.simple_text and len(children) == len(root.attrib) == 0:
                     value = self._fromstring(text)
                 else:
@@ -245,8 +245,8 @@ class Abdera(XMLData):
 
         # Add root text
         if root.text and self.text_content is not None:
-            text = root.text.strip()
-            if text:
+            text = root.text
+            if text.strip():
                 if self.simple_text and len(children) == len(root.attrib) == 0:
                     value = self._fromstring(text)
                 else:
@@ -328,8 +328,8 @@ class Cobra(XMLData):
 
         # Add root text
         if root.text and self.text_content is not None:
-            text = root.text.strip()
-            if text:
+            text = root.text
+            if text.strip():
                 if self.simple_text and len(children) == len(root.attrib) == 0:
                     value = self._fromstring(text)
                 else:


### PR DESCRIPTION
It is not part of the XML spec to strip spaces from tag values. This is causing problems in a project I'm working on where things like:

```
<string>W3lcOme\ </string>
```

become
```
"W3lcOme\"
```

I tried to justify it by attempting to find something in the specification that says whitespace should be stripped, but all I could find was contrary documentation saying whitespace in tag text should be preserved.